### PR TITLE
3.0.0-RC2: Scala-js and SuperSafe

### DIFF
--- a/app/views/install.scala.html
+++ b/app/views/install.scala.html
@@ -49,8 +49,14 @@ The <a href="https://oss.sonatype.org/content/groups/public/org/scalactic/scalac
 libraryDependencies += <span class="stQuotedString">"org.scalactic"</span> %% <span class="stQuotedString">"scalactic"</span> % <span class="stQuotedString">"2.2.6"</span>
 </pre>
 
+If you're using pre-release 3.0.0-RC2, which supports scala-js, you should use <code>%%%</code> instead in your scala-js project:
+
+<pre class="stHighlighted">
+libraryDependencies += <span class="stQuotedString">"org.scalactic"</span> %%% <span class="stQuotedString">"scalactic"</span> % <span class="stQuotedString">"3.0.0-RC2"</span>
+</pre>
+
 <p>
-2. We also recommend you also include the <a href="/supersafe">SuperSafe Community Edition</a> Scala compiler plugin, which will flag errors in your 
+2. If you're using pre-release 3.0.0-RC2, we recommend you to also include the <a href="/supersafe">SuperSafe Community Edition</a> Scala compiler plugin, which will flag errors in your
 Scalactic code at compile time, by first adding this line to <code>~/.sbt/0.13/global.sbt</code>:
 </p>
 
@@ -63,7 +69,7 @@ resolvers += <span class="stQuotedString">"Artima Maven Repository"</span> at <s
 </p>
 
 <pre class="stHighlighted">
-addSbtPlugin(<span class="stQuotedString">"com.artima.supersafe"</span> % <span class="stQuotedString">"sbtplugin"</span> % <span class="stQuotedString">"1.1.0-RC6"</span>)
+addSbtPlugin(<span class="stQuotedString">"com.artima.supersafe"</span> % <span class="stQuotedString">"sbtplugin"</span> % <span class="stQuotedString">"1.1.0-RC7"</span>)
 </pre>
 
 <p>
@@ -89,7 +95,7 @@ You are off and running! As a next step, visit the <a href="/user_guide">Getting
 </pre>
 
 <p>
-2. We also recommend you also include the <a href="/supersafe">SuperSafe Community Edition</a> Scala compiler plugin, which will flag errors in your
+2. If you're using pre-release 3.0.0-RC2, we recommend you to also include the <a href="/supersafe">SuperSafe Community Edition</a> Scala compiler plugin, which will flag errors in your
 Scalactic code at compile time, by adding the following lines to your <code>pom.xml</code>:
 </p>
 


### PR DESCRIPTION
Updated installation guide to include scala-js and SuperSafe correctly.
