### PR TITLE
SuperSafe 1.1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ scalactic-website
 
 Scalactic Official Website
 
+# Development
+
+To run the site locally: 
+
+```
+> export APP_SECRET=12345678
+> sbt run
+```
+
 # Docker
 
 Update version in build.sbt, then publish docker image locally: 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -62,14 +62,14 @@ object Application {
   val latestScaladoc = "http://doc.scalatest.org/3.1.1"
   val latestScalacticScaladoc = "http://doc.scalactic.org/3.1.1"
   val latestVersion = "3.1.1"
-  val latestSuperSafeVersion = "1.1.9"
+  val latestSuperSafeVersion = "1.1.10"
   val milestoneVersion = "3.1.0-RC3"
   val milestoneJar = "https://oss.sonatype.org/content/groups/public/org/scalactic/scalactic_2.13/3.1.0-RC3/scalactic_2.10-3.1.0-RC3.jar"
   val latestJar = "https://oss.sonatype.org/content/groups/public/org/scalactic/scalactic_2.13/3.1.1/scalactic_2.13-3.1.1.jar"
   val milestoneScaladoc = "http://www.artima.com/docs-scalatest-3.1.0-RC3"
   val scaladocsLocation = "http://doc.scalatest.org"
   val releasesLocation = "http://www.artima.com/downloadScalaTest"
-  val baseScalaVersion = "2.13.0"			
+  val baseScalaVersion = "2.13.1"			
   val majorMinorScalaVersion = "2.13"
 
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -69,7 +69,7 @@ object Application {
   val milestoneScaladoc = "http://www.artima.com/docs-scalatest-3.1.0-RC3"
   val scaladocsLocation = "http://doc.scalatest.org"
   val releasesLocation = "http://www.artima.com/downloadScalaTest"
-  val baseScalaVersion = "2.13.1"			
+  val baseScalaVersion = "2.13.2"			
   val majorMinorScalaVersion = "2.13"
 
 }

--- a/app/views/supersafe.scala.html
+++ b/app/views/supersafe.scala.html
@@ -87,19 +87,7 @@ http://www.artima.com/supersafe_user_guide.html#safer-equality
 <h2>Installation of SuperSafe Community Edition</h2>
 
 <p>
-If you are using sbt as your build tool, you can install the SuperSafe Community Edition in two easy steps.
-</p>
-
-<p>
-1. Add the <em>Artima Maven Repository</em> as a resolver in ~/.sbt/0.13/global.sbt, like this:
-</p>
-
-<pre class="stGrayback">
-resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases"
-</pre>
-
-<p>
-2. Add the following line to your project/plugins.sbt:
+If you are using sbt as your build tool, you can install the SuperSafe Community Edition by adding the following line to your project/plugins.sbt:
 </p>
 
 <pre class="stGrayback">
@@ -107,25 +95,7 @@ addSbtPlugin("com.artima.supersafe" % "sbtplugin" % "@{latestSuperSafeVersion}")
 </pre>
 
 <p>
-If you are using Maven as your build tool, you can install the community edition of SuperSafe in two easy steps. 
-</p>
-
-<p>
-1. Add the <em>Artima Maven Repository</em> to your <code>pom.xml</code>, like this:
-</p>
-
-<pre class="stGrayback">
-&lt;repositories&gt;
-    <b>&lt;repository&gt;
-        &lt;id&gt;artima&lt;/id&gt;
-        &lt;name&gt;Artima Maven Repository&lt;/name&gt;
-        &lt;url&gt;http://repo.artima.com/releases&lt;/url&gt;
-    &lt;/repository&gt;</b>
-&lt;/repositories&gt;
-</pre>
-
-<p>
-2. Add the compiler plugin to your <code>pom.xml</code>, like this:
+If you are using Maven as your build tool, you can install the community edition of SuperSafe by adding the compiler plugin to your <code>pom.xml</code>, like this:
 </p>
 
 <pre class="stGrayback">


### PR DESCRIPTION
Changed supersafe version to 1.1.10, and remove the step to add artima repository as it is now mirror by maven central.