### PR TITLE
ScalaDoc Links Refactor

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -60,7 +60,6 @@ class Application extends Controller {
 object Application {
 
   val latestScaladoc = "http://doc.scalatest.org/3.2.5"
-  val latestScalacticScaladoc = "http://doc.scalactic.org/3.2.5"
   val latestVersion = "3.2.5"
   val latestSuperSafeVersion = "1.1.11"
   val milestoneVersion = "3.1.0-RC3"

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -59,7 +59,6 @@ class Application extends Controller {
 
 object Application {
 
-  val latestScaladoc = "http://doc.scalatest.org/3.2.5"
   val latestVersion = "3.2.5"
   val latestSuperSafeVersion = "1.1.11"
   val milestoneVersion = "3.1.0-RC3"
@@ -80,5 +79,16 @@ object Application {
       else s"$version/${file.replaceAll("\\.", "/")}.html"
 
     routes.Assets.at("/public/scaladoc", filePath).toString
+  }
+
+  def scalatestScaladocsPageUrl(file: String, version: String = latestVersion): String = {
+    val oldScaladocStyle30Releases = List("3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.0.4")
+    val filePath =
+      if (version.startsWith("1.") || version.startsWith("2.") || oldScaladocStyle30Releases.contains(version)) {
+        s"$version/index.html#$file"
+      }
+      else s"$version/${file.replaceAll("\\.", "/")}.html"
+
+    s"https://www.scalatest.org/scaladoc/$filePath"
   }
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -15,7 +15,6 @@
  *@
 
 @import controllers.Application.majorMinorScalaVersion
-@import controllers.Application.latestScaladoc
 @import controllers.Application.scaladocsPageUrl
 
 @homePage("Home") {

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -16,7 +16,7 @@
 
 @import controllers.Application.majorMinorScalaVersion
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @homePage("Home") {
 
@@ -43,7 +43,7 @@
 
     <p>
     For example, you can compare strings for equality after being normalized by forcing them to lowercase by customizing
-    <a href="@latestScalacticScaladoc/#org.scalactic.Equality"><code>Equality</code></a> explicitly, like this:
+    <a href='@scaladocsPageUrl("org.scalactic.Equality")'><code>Equality</code></a> explicitly, like this:
     </p>
 
     <pre class="scala">
@@ -56,7 +56,7 @@
     </pre>
 
     <p>
-    You can also define implicit <a href="@latestScalacticScaladoc/#org.scalactic.Normalization"><code>Normalization</code></a> strategies for types and access
+    You can also define implicit <a href='@scaladocsPageUrl("org.scalactic.Normalization")'><code>Normalization</code></a> strategies for types and access
     them by invoking <code>norm</code> methods:
     </p>
 
@@ -71,7 +71,7 @@
 
     <p>
     The &ldquo;<code>after being lowerCased</code>&rdquo; syntax shown previously is provided by Scalactic'
-    <a href="@latestScalacticScaladoc/#org.scalactic.Explicitly"><code>Explicitly</code></a> DSL, which allows you to specify <code>Equality</code>
+    <a href='@scaladocsPageUrl("org.scalactic.Explicitly")'><code>Explicitly</code></a> DSL, which allows you to specify <code>Equality</code>
     explicitly. You can also define custom <code>Equality</code>s implicitly:
     </p>
 
@@ -84,7 +84,7 @@
     </pre>
 
     <p>
-    You can compare numeric values for equality with a <a href="@latestScalacticScaladoc/#org.scalactic.Tolerance"><code>Tolerance</code></a>, like this:
+    You can compare numeric values for equality with a <a href='@scaladocsPageUrl("org.scalactic.Tolerance")'><code>Tolerance</code></a>, like this:
     </p>
 
     <pre class="scala">
@@ -94,7 +94,7 @@
     </pre>
 
     <p>
-    Or you could use <a href="@latestScalacticScaladoc/#org.scalactic.TolerantNumerics"><code>TolerantNumerics</code></a> define an implicit <code>Equality[Double]</code> that
+    Or you could use <a href='@scaladocsPageUrl("org.scalactic.TolerantNumerics")'><code>TolerantNumerics</code></a> define an implicit <code>Equality[Double]</code> that
     compares <code>Double</code>s with a tolerance:
     </p>
 
@@ -124,13 +124,13 @@
     <h1><code>Or</code> and <code>Every</code></h1>
 
     <p>
-      Scalactic provides an &ldquo;<code>Either</code> with attitude&rdquo; named <a href="@latestScalacticScaladoc/#org.scalactic.Or"><code>Or</code></a>, designed for
+      Scalactic provides an &ldquo;<code>Either</code> with attitude&rdquo; named <a href='@scaladocsPageUrl("org.scalactic.Or")'><code>Or</code></a>, designed for
       functional error handling. <code>Or</code> gives you
       more convenient chaining of <code>map</code> and <code>flatMap</code> calls (and <code>for</code> expressions) than <code>Either</code> and, when, combined
-      with <a href="@latestScalacticScaladoc/#org.scalactic.Every"><code>Every</code></a>, enables you to accumulate errors. <code>Every</code> is an ordered
-      collection of one or more elements. An <code>Or</code> is either <a href="@latestScalacticScaladoc/#org.scalactic.Good"><code>Good</code></a> or
-      <a href="@latestScalacticScaladoc/#org.scalactic.Bad"><code>Bad</code></a>. An <code>Every</code> is either
-      <a href="@latestScalacticScaladoc/#org.scalactic.One"><code>One</code></a> or <a href="@latestScalacticScaladoc/#org.scalactic.Many"><code>Many</code></a>. Here's an
+      with <a href='@scaladocsPageUrl("org.scalactic.Every")'><code>Every</code></a>, enables you to accumulate errors. <code>Every</code> is an ordered
+      collection of one or more elements. An <code>Or</code> is either <a href='@scaladocsPageUrl("org.scalactic.Good")'><code>Good</code></a> or
+      <a href='@scaladocsPageUrl("org.scalactic.Bad")'><code>Bad</code></a>. An <code>Every</code> is either
+      <a href='@scaladocsPageUrl("org.scalactic.One")'<code>One</code></a> or <a href='@scaladocsPageUrl("org.scalactic.Many")'><code>Many</code></a>. Here's an
       example of accumulating errors with <code>Or</code> and <code>Every</code>:
     </p>
 
@@ -186,13 +186,13 @@ parsePerson(<span class="quotedString">&quot;Bridget Jones&quot;</span>, <span c
 
 <p>
 <code>Or</code> offers several other ways to accumulate errors besides the <code>withGood</code> methods shown in the example above. See the
-<a href="@latestScalacticScaladoc/#org.scalactic.Or">documentation for <code>Or</code></a> for more information.
+<a href='@scaladocsPageUrl("org.scalactic.Or")'>documentation for <code>Or</code></a> for more information.
 </p>
 
     <h1><code>Requirements</code> and <code>Snapshots</code></h1>
 
 <p>
-Scalactic includes a <a href="@latestScalacticScaladoc/#org.scalactic.Requirements"><code>Requirements</code></a> trait that offers
+Scalactic includes a <a href='@scaladocsPageUrl("org.scalactic.Requirements")'><code>Requirements</code></a> trait that offers
 <code>require</code>, <code>requireState</code>, and <code>requireNonNull</code> methods for checking pre-conditions
 that give descriptive error messages extracted via a macro. Here are some examples:</p>
 </p>
@@ -213,7 +213,7 @@ requireNonNull(a, b)
 </pre>
 
 <p>
-Trait <a href="@latestScalacticScaladoc/#org.scalactic.Snapshots"><code>Snapshots</code></a> offers a
+Trait <a href='@scaladocsPageUrl("org.scalactic.Snapshots")'><code>Snapshots</code></a> offers a
 <code>snap</code> method that can help you make debug and log messages that include information about
 the values of variables:
 </p>
@@ -229,7 +229,7 @@ snap(a, b, c) <span class="lineComment">// Result: a was 1, b was '2', c was "3"
     <h1>And more (but not much more)...</h1>
 
 <p>
-Scalactic also includes a <a href="@latestScalacticScaladoc/#org.scalactic.TimesOnInt"><code>TimesOnInt</code></a> trait that allows you to perform
+Scalactic also includes a <a href='@scaladocsPageUrl("org.scalactic.TimesOnInt")'><code>TimesOnInt</code></a> trait that allows you to perform
 side-effecting loops a specified number of times, like this:
 </p>
 
@@ -240,8 +240,8 @@ import TimesOnInt._
 </pre>
 
 <p>
-You can also define an alternate <code>String</code> forms for types using <a href="@latestScalacticScaladoc/#org.scalactic.Prettifier"><code>Prettifier</code></a>s
-and create extractors for <code>Throwable</code>s via the <a href="@latestScalacticScaladoc/#org.scalactic.Catcher"><code>Catcher</code></a> factory.
+You can also define an alternate <code>String</code> forms for types using <a href='@scaladocsPageUrl("org.scalactic.Prettifier")'><code>Prettifier</code></a>s
+and create extractors for <code>Throwable</code>s via the <a href='@scaladocsPageUrl("org.scalactic.Catcher")'><code>Catcher</code></a> factory.
 </p>
 
 <p>

--- a/app/views/quickStart.scala.html
+++ b/app/views/quickStart.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import controllers.Application.latestScaladoc
 @import controllers.Application.scaladocsPageUrl
 @import controllers.Application.latestVersion
 @import controllers.Application.latestJar

--- a/app/views/quickStart.scala.html
+++ b/app/views/quickStart.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 @import controllers.Application.latestVersion
 @import controllers.Application.latestJar
 @import controllers.Application.majorMinorScalaVersion
@@ -176,9 +176,9 @@ scala&gt; List(1, 2, 3) === Set(1, 2, 3)
 
 <p>
 In short, Scalactic's type-checking <code>===</code> operator provides you with a tunable type check for equality comparisons. For more
-information, see the documentation for <a href="@latestScalacticScaladoc/#org.scalactic.TypeCheckedTripleEquals"><code>TypeCheckedTripleEquals</code></a>,
-<a href="@latestScalacticScaladoc/#org.scalactic.ConversionCheckedTripleEquals"><code>ConversionCheckedTripleEquals</code></a>, and
-<a href="@latestScalacticScaladoc/#org.scalactic.TraversableEqualityConstraints"><code>TraversableEqualityConstraints</code></a>.
+information, see the documentation for <a href='@scaladocsPageUrl("org.scalactic.TypeCheckedTripleEquals")'><code>TypeCheckedTripleEquals</code></a>,
+<a href='@scaladocsPageUrl("org.scalactic.ConversionCheckedTripleEquals")'><code>ConversionCheckedTripleEquals</code></a>, and
+<a href='@scaladocsPageUrl("org.scalactic.TraversableEqualityConstraints")'><code>TraversableEqualityConstraints</code></a>.
 </p>
 
 <p>

--- a/app/views/releaseNotes/v210.scala.html
+++ b/app/views/releaseNotes/v210.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import controllers.Application.latestScaladoc
 @import controllers.Application.scaladocsPageUrl
 
 @releaseNotesPage("Scalactic 2.1.0 Release Notes") {

--- a/app/views/releaseNotes/v210.scala.html
+++ b/app/views/releaseNotes/v210.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @releaseNotesPage("Scalactic 2.1.0 Release Notes") {
 <div style="text-align: left">
@@ -40,10 +40,10 @@ Scalactic 2.1.0 includes the following enhancements:
 <h2>Enhancements</h2>
 
 <ul>
-<li>Enhanced default <a href="@{latestScalacticScaladoc}/index.html#org.scalactic.Prettifier"><code>Prettifier</code></a> to prettify objects inside Scala and Java collections, <code>Option</code>, <code>Either</code>, <code>Try</code>, and Scalactic's <a href="@{latestScalacticScaladoc}/index.html#org.scalactic.Or"><code>Or</code></a> and <a href="@{latestScalacticScaladoc}/index.html#org.scalactic.Every"><code>Every</code></a>.</li>
-<li>Added <code>badMap</code> and <code>fold</code> methods to <a href="@{latestScalacticScaladoc}/index.html#org.scalactic.Or"><code>Or</code></a>.</li>
-<li>Added a <code>toEquality</code> method on <a href="@{latestScalacticScaladoc}/index.html#org.scalactic.Uniformity"><code>Uniformity</code></a>
-and a <code>toEquivalence</code> method on <a href="@{latestScalacticScaladoc}/index.html#org.scalactic.Normalization"><code>Normalization</code></a> to provide a way
+<li>Enhanced default <a href='@scaladocsPageUrl("org.scalactic.Prettifier")'><code>Prettifier</code></a> to prettify objects inside Scala and Java collections, <code>Option</code>, <code>Either</code>, <code>Try</code>, and Scalactic's <a href='@scaladocsPageUrl("org.scalactic.Or")'><code>Or</code></a> and <a href='@scaladocsPageUrl("org.scalactic.Every")'><code>Every</code></a>.</li>
+<li>Added <code>badMap</code> and <code>fold</code> methods to <a href='@scaladocsPageUrl("org.scalactic.Or")'><code>Or</code></a>.</li>
+<li>Added a <code>toEquality</code> method on <a href='@scaladocsPageUrl("org.scalactic.Uniformity")'><code>Uniformity</code></a>
+and a <code>toEquivalence</code> method on <a href='@scaladocsPageUrl("org.scalactic.Normalization")'><code>Normalization</code></a> to provide a way
 to convert a normalization to an equality without using the <code>Explicitly</code> DSL. Modified Scaladoc documentation to include
 examples of explicitly specifying equality without using the <code>Explicitly</code> DSL, for people who prefer to avoid English-like DSLs in production code.</li>
 

--- a/app/views/supersafe.scala.html
+++ b/app/views/supersafe.scala.html
@@ -16,7 +16,6 @@
 
 @import controllers.Application.latestSuperSafeVersion
 @import controllers.Application.scaladocsPageUrl
-@import controllers.Application.latestScaladoc
 @import controllers.Application.baseScalaVersion
 
 @nonHomePage("SuperSafe") {

--- a/app/views/supersafe.scala.html
+++ b/app/views/supersafe.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import controllers.Application.latestSuperSafeVersion
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 @import controllers.Application.latestScaladoc
 @import controllers.Application.baseScalaVersion
 
@@ -26,7 +26,7 @@
 
 <p>
 <a href="http://www.artima.com/supersafe_user_guide.html">Artima SuperSafe</a> is a commercial Scala compiler plugin with a free Community Edition
-that checks Scalactic <a href="@latestScalacticScaladoc/#org.scalactic.TripleEquals"><code>TripleEquals</code></a> (<code>===</code> and <code>!==</code>) expressions for correctness.
+that checks Scalactic <a href='@scaladocsPageUrl("org.scalactic.TripleEquals")'><code>TripleEquals</code></a> (<code>===</code> and <code>!==</code>) expressions for correctness.
 Using SuperSafe Community Edition together with Scalactic can save you time and ensure certain
 errors do not exist in your code. (See the
 <a href="#installation">installation section</a> below for instructions

--- a/app/views/userGuide/Explicitly.scala.html
+++ b/app/views/userGuide/Explicitly.scala.html
@@ -14,7 +14,7 @@
 * limitations under the License.
 *@
 
-@import controllers.Application.latestScaladoc
+@import controllers.Application.scalatestScaladocsPageUrl
 @import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("The Explicitly DSL") {
@@ -31,7 +31,7 @@ explicit specification of an <a href='@scaladocsPageUrl("org.scalactic.Equality"
 <p>
 The Explicitly DSL can be used with the <code>===</code> and <code>!==</code> operators of Scalactic
 as well as the <code>should</code> <code>equal</code>, <code>be</code>, <code>contain</code>, and
-<code>===</code> syntax of <a href="@{latestScaladoc}/#org.scalatest.Matchers">ScalaTest matchers</a>.
+<code>===</code> syntax of <a href='@scalatestScaladocsPageUrl("org.scalatest.Matchers")'>ScalaTest matchers</a>.
 </p>
 
 <p>

--- a/app/views/userGuide/Explicitly.scala.html
+++ b/app/views/userGuide/Explicitly.scala.html
@@ -15,7 +15,7 @@
 *@
 
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("The Explicitly DSL") {
 <div style="text-align: left">
@@ -23,9 +23,9 @@
 <h1>The Explicitly DSL</h1>
 
 <p>
-Scalactic's <a href="@{latestScalacticScaladoc}/#org.scalactic.Explicitly"><code>Explicitly</code></a> trait provides the &ldquo;explicitly DSL,&rdquo; which facilitates the
-explicit specification of an <a href="@{latestScalacticScaladoc}/#org.scalactic.Equality"><code>Equality[T]</code></a> or a
-<a href="@{latestScalacticScaladoc}/#org.scalactic.Uniformity"><code>Uniformity[T]</code></a> where <code>Equality[T]</code> is taken implicitly.
+Scalactic's <a href='@scaladocsPageUrl("org.scalactic.Explicitly")'><code>Explicitly</code></a> trait provides the &ldquo;explicitly DSL,&rdquo; which facilitates the
+explicit specification of an <a href='@scaladocsPageUrl("org.scalactic.Equality")'><code>Equality[T]</code></a> or a
+<a href='@scaladocsPageUrl("org.scalactic.Uniformity")'><code>Uniformity[T]</code></a> where <code>Equality[T]</code> is taken implicitly.
 </p>
 
 <p>
@@ -54,7 +54,7 @@ result should equal ("hello") (decided by defaultEquality)
 
 <p>
 The explicitly DSL also provides support for specifying a one-off equality that is based on a normalization. For
-example, Scalactic offers a <a href="@{latestScalacticScaladoc}/#org.scalactic.StringNormalizations"><code>StringNormalizations</code></a>
+example, Scalactic offers a <a href='@scaladocsPageUrl("org.scalactic.StringNormalizations")'><code>StringNormalizations</code></a>
 trait that provides methods such as <code>trimmed</code> and <code>lowerCased</code> that return <code>Uniformity[String]</code>
 instances that normalize by trimming and lower-casing, respectively. If you bring those into scope by mixing in or importing the
 members of <code>StringNormalizations</code>, you could use the explicitly DSL like this:

--- a/app/views/userGuide/Normalization.scala.html
+++ b/app/views/userGuide/Normalization.scala.html
@@ -15,7 +15,7 @@
 *@
 
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Normalization") {
 <div style="text-align: left">
@@ -23,7 +23,7 @@
 <h1>Normalization</h1>
 
 <p>
-The Scalactic <a href="@{latestScalacticScaladoc}/#org.scalactic.Normalization"><code>Normalization</code></a> trait allows you to define a custom ways normalize objects based on their type.
+The Scalactic <a href='@scaladocsPageUrl("org.scalactic.Normalization")'><code>Normalization</code></a> trait allows you to define a custom ways normalize objects based on their type.
 </p>
 
 <p>
@@ -54,15 +54,15 @@ Given this definition you could use it with the <a href="@routes.UserGuide.expli
 
 <p>
 Note that to use a <code>Normalization</code> with the <code>Explicitly</code> DSL, you'll need to be using either
-<a href="@{latestScalacticScaladoc}/#org.scalactic.TypeCheckedTripleEquals"><code>TypeCheckedTripleEquals</code></a> or
-<a href="@{latestScalacticScaladoc}/#org.scalactic.ConversionCheckedTripleEquals"><code>ConversionCheckedTripleEquals</code></a>.
-If you're just using plain-old <a href="@{latestScalacticScaladoc}/#org.scalactic.TripleEquals"><code>TripleEquals</code></a>,
-you'll need a <a href="@{latestScalacticScaladoc}/#org.scalactic.Uniformity"><code>Uniformity</code></a> (described below), a <code>Normalization</code> subtrait.
+<a href='@scaladocsPageUrl("org.scalactic.TypeCheckedTripleEquals")'><code>TypeCheckedTripleEquals</code></a> or
+<a href='@scaladocsPageUrl("org.scalactic.ConversionCheckedTripleEquals")'><code>ConversionCheckedTripleEquals</code></a>.
+If you're just using plain-old <a href='@scaladocsPageUrl("org.scalactic.TripleEquals")'><code>TripleEquals</code></a>,
+you'll need a <a href='@scaladocsPageUrl("org.scalactic.Uniformity")'><code>Uniformity</code></a> (described below), a <code>Normalization</code> subtrait.
 </p>
 
 <p>
 If you make the <code>truncated</code> <code>val</code> implicit and import or mix in the members of
-<a href="@{latestScalacticScaladoc}/#org.scalactic.NormMethods"><code>NormMethods</code></a>,
+<a href='@scaladocsPageUrl("org.scalactic.NormMethods")'><code>NormMethods</code></a>,
 you can access the behavior by invoking <code>.norm</code> on <code>Double</code>s.
 </p>
 
@@ -77,7 +77,7 @@ d.norm // returns 2.0
 <h1>Uniformity</h1>
 
 <p>
-An important subtype of <code>Normalization</code> is <a href="@{latestScalacticScaladoc}/#org.scalactic.Uniformity"><code>Uniformity</code></a>, which
+An important subtype of <code>Normalization</code> is <a href='@scaladocsPageUrl("org.scalactic.Uniformity")'><code>Uniformity</code></a>, which
 defines a custom way to normalize instances of a type that can also handle normalization of that type when passed as <code>Any</code>.
 </p>
 
@@ -101,7 +101,7 @@ you might write:
 </pre>
 
 <p>
-Given this definition you could use it with the <a href="@{latestScalacticScaladoc}/#org.scalactic.Explicitly"><code>Explicitly</code></a> DSL like this:
+Given this definition you could use it with the <a href='@scaladocsPageUrl("org.scalactic.Explicitly")'><code>Explicitly</code></a> DSL like this:
 </p>
 
 <pre class="stHighlighted">
@@ -123,11 +123,11 @@ d.norm <span class="stLineComment">// returns 2.0</span>
 </pre>
 
 <p>
-As mentioned previously, by creating a <code>Uniformity</code> rather than just an instance of its supertype, <a href="@{latestScalacticScaladoc}/#org.scalactic.Normalization"><code>Normalization</code></a>,
+As mentioned previously, by creating a <code>Uniformity</code> rather than just an instance of its supertype, <a href='@scaladocsPageUrl("org.scalactic.Normalization")'><code>Normalization</code></a>,
 it can be used more generally. For example, <code>Uniformity</code>s allow you to the <code>Explicitly</code> DSL with
-<a href="@{latestScalacticScaladoc}/#org.scalactic.TripleEquals"><code>TripleEquals</code></a>, whereas <code>Normalization</code>s require
-<a href="@{latestScalacticScaladoc}/#org.scalactic.TypeCheckedTripleEquals"><code>TypeCheckedTripleEquals</code></a> or
-<a href="@{latestScalacticScaladoc}/#org.scalactic.ConversionCheckedTripleEquals"><code>ConversionCheckedTripleEquals</code></a>.
+<a href='@scaladocsPageUrl("org.scalactic.TripleEquals")'><code>TripleEquals</code></a>, whereas <code>Normalization</code>s require
+<a href='@scaladocsPageUrl("org.scalactic.TypeCheckedTripleEquals")'><code>TypeCheckedTripleEquals</code></a> or
+<a href='@scaladocsPageUrl("org.scalactic.ConversionCheckedTripleEquals")'><code>ConversionCheckedTripleEquals</code></a>.
 <code>Uniformity</code>s also enable you to use the <code>Explicitly</code> DSL with ScalaTest's <code>should</code> <code>===</code>, <code>equal</code>,
 and <code>contain</code> matcher syntax, whereas a plain <code>Normalization</code> can only be used with <code>should</code> <code>===</code>, and only
 under either <code>TypeCheckedTripleEquals</code> or <code>ConversionCheckedTripleEquals</code>.

--- a/app/views/userGuide/Normalization.scala.html
+++ b/app/views/userGuide/Normalization.scala.html
@@ -14,7 +14,7 @@
 * limitations under the License.
 *@
 
-@import controllers.Application.latestScaladoc
+@import controllers.Application.scalatestScaladocsPageUrl
 @import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Normalization") {
@@ -111,7 +111,7 @@ Given this definition you could use it with the <a href='@scaladocsPageUrl("org.
 </pre>
 
 <p>
-If you make the <code>truncated</code> <code>val</code> implicit and import or mix in the members of <a href="@{latestScaladoc}/#org.scalactic.NormMethods"><code>NormMethods</code></a>,
+If you make the <code>truncated</code> <code>val</code> implicit and import or mix in the members of <a href='@scalatestScaladocsPageUrl("org.scalactic.NormMethods")'><code>NormMethods</code></a>,
 you can access the behavior by invoking <code>.norm</code> on <code>Double</code>s.
 </p>
 

--- a/app/views/userGuide/OrAndEvery.scala.html
+++ b/app/views/userGuide/OrAndEvery.scala.html
@@ -14,7 +14,7 @@
 * limitations under the License.
 *@
 
-@import controllers.Application.latestScaladoc
+@import controllers.Application.scalatestScaladocsPageUrl
 @import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Or and Every") {

--- a/app/views/userGuide/OrAndEvery.scala.html
+++ b/app/views/userGuide/OrAndEvery.scala.html
@@ -15,7 +15,7 @@
 *@
 
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Or and Every") {
 <div style="text-align: left">
@@ -23,13 +23,13 @@
 <h1>Or and Every</h1>
 
 <p>
-The <a href="@{latestScalacticScaladoc}/#org.scalactic.Or"><code>Or</code></a> and <a href="@{latestScalacticScaladoc}/#org.scalactic.Every"><code>Every</code></a>
+The <a href='@scaladocsPageUrl("org.scalactic.Or")'><code>Or</code></a> and <a href='@scaladocsPageUrl("org.scalactic.Every")'><code>Every</code></a>
 types of Scalactic allow you to represent errors as an &ldquo;alternate return
 value&rdquo; (like <code>Either</code>) and to optionally accumulate errors.
 <code>Or</code> represents a value that is one of two possible types, with one type being &ldquo;good&rdquo;
-(a value wrapped in an instance of <a href="@{latestScalacticScaladoc}/#org.scalactic.Good"><code>Good</code></a>)
+(a value wrapped in an instance of <a href='@scaladocsPageUrl("org.scalactic.Good")'><code>Good</code></a>)
 and the other &ldquo;bad&rdquo;
-(a value wrapped in an instance of <a href="@{latestScalacticScaladoc}/#org.scalactic.Bad"><code>Bad</code></a>).
+(a value wrapped in an instance of <a href='@scaladocsPageUrl("org.scalactic.Bad")'><code>Bad</code></a>).
 </p>
 
 <h2>The motivation for <code>Or</code></h2>
@@ -283,11 +283,11 @@ parsePerson("", "")
 
 <p>
 Another difference between <code>Or</code> and <code>Either</code> is that <code>Or</code> enables
-you to accumulate errors if the <code>Bad</code> type is an <a href="@{latestScalacticScaladoc}/#org.scalactic.Every"><code>Every</code></a>.
+you to accumulate errors if the <code>Bad</code> type is an <a href='@scaladocsPageUrl("org.scalactic.Every")'><code>Every</code></a>.
 An <code>Every</code> is similar to a <code>Seq</code> in that it contains ordered elements, but
 different from <code>Seq</code> in that it cannot be empty. An <code>Every</code> is
-either a <a href="@{latestScalacticScaladoc}/#org.scalactic.One"><code>One</code></a>,
-which contains one and only one element, or a <a href="@{latestScalacticScaladoc}/#org.scalactic.Many"><code>Many</code></a>, which contains two or
+either a <a href='@scaladocsPageUrl("org.scalactic.One")'><code>One</code></a>,
+which contains one and only one element, or a <a href='@scaladocsPageUrl("org.scalactic.Many")'><code>Many</code></a>, which contains two or
 more elements.
 </p>
 
@@ -329,7 +329,7 @@ Because <code>parseName</code> will either return a valid name <code>String</cod
 <p>
 Because a <code>for</code> expression short-circuits on the first <code>Bad</code> encountered, you'll
 need to use a different approach to write the <code>parsePerson</code> method. In this example, the
-<code>withGood</code> method from trait <a href="@{latestScalacticScaladoc}/#org.scalactic.Accumulation"><code>Accumulation</code></a>
+<code>withGood</code> method from trait <a href='@scaladocsPageUrl("org.scalactic.Accumulation")'><code>Accumulation</code></a>
 will do the trick:
 </p>
 

--- a/app/views/userGuide/Requirements.scala.html
+++ b/app/views/userGuide/Requirements.scala.html
@@ -15,14 +15,14 @@
 *@
 
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Requirements") {
 <div style="text-align: left">
 
 <h1>Requirements</h1>
 
-<p>The <a href="@{latestScalacticScaladoc}/#org.scalactic.Requirements">Requirements</a> trait that contains <code>require</code>, and <code>requireState</code>, and <code>requireNonNull</code> methods for checking pre-conditions
+<p>The <a href='@scaladocsPageUrl("org.scalactic.Requirements")'>Requirements</a> trait that contains <code>require</code>, and <code>requireState</code>, and <code>requireNonNull</code> methods for checking pre-conditions
 that give descriptive error messages extracted via a macro.</p><p>These methods of trait <code>Requirements</code> aim to improve error messages provided when a pre-condition check fails at runtime in
 production code. Although it is recommended practice to supply helpful error messages when doing pre-condition checks, often people
 don't. Instead of this:</p>

--- a/app/views/userGuide/Requirements.scala.html
+++ b/app/views/userGuide/Requirements.scala.html
@@ -14,7 +14,7 @@
 * limitations under the License.
 *@
 
-@import controllers.Application.latestScaladoc
+@import controllers.Application.scalatestScaladocsPageUrl
 @import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Requirements") {

--- a/app/views/userGuide/Snapshots.scala.html
+++ b/app/views/userGuide/Snapshots.scala.html
@@ -15,15 +15,15 @@
 *@
 
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Snapshots") {
 <div style="text-align: left">
 
 <h1>Snapshots</h1>
 
-<p>The <a href="@{latestScalacticScaladoc}/#org.scalactic.Snapshots">Snapshots</a> trait provides a <code>snap</code> method that takes one or more arguments and results in a
-<a href="@{latestScalacticScaladoc}/#org.scalactic.SnapshotSeq"><code>SnapshotSeq</code></a>, whose <code>toString</code> lists the names
+<p>The <a href='@scaladocsPageUrl("org.scalactic.Snapshots")'>Snapshots</a> trait provides a <code>snap</code> method that takes one or more arguments and results in a
+<a href='@scaladocsPageUrl("org.scalactic.SnapshotSeq")'><code>SnapshotSeq</code></a>, whose <code>toString</code> lists the names
 and values of each argument.</p><p>The intended use case of this trait is to help you write debug and log
 messages that give a &quot;snapshot&quot; of program state. Here's an example:</p><p><pre class="stREPL">
 scala&gt; import Snapshots._

--- a/app/views/userGuide/Snapshots.scala.html
+++ b/app/views/userGuide/Snapshots.scala.html
@@ -14,7 +14,7 @@
 * limitations under the License.
 *@
 
-@import controllers.Application.latestScaladoc
+@import controllers.Application.scalatestScaladocsPageUrl
 @import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Snapshots") {

--- a/app/views/userGuide/TimesOnInt.scala.html
+++ b/app/views/userGuide/TimesOnInt.scala.html
@@ -16,7 +16,7 @@
 
 @import controllers.Application.milestoneScaladoc
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("TimesOnInt") {
 <div style="text-align: left">
@@ -24,7 +24,7 @@
 <h1>TimesOnInt</h1>
 
 <p>
-The <a href="@{latestScalacticScaladoc}/#org.scalactic.TimesOnInt"><code>TimesOnInt</code></a> trait providing an implicit conversion that adds
+The <a href='@scaladocsPageUrl("org.scalactic.TimesOnInt")'><code>TimesOnInt</code></a> trait providing an implicit conversion that adds
 a <code>times</code> method to <code>Int</code>s that will repeat a given side-effecting operation multiple times.
 </p>
 

--- a/app/views/userGuide/TimesOnInt.scala.html
+++ b/app/views/userGuide/TimesOnInt.scala.html
@@ -15,7 +15,7 @@
 *@
 
 @import controllers.Application.milestoneScaladoc
-@import controllers.Application.latestScaladoc
+@import controllers.Application.scalatestScaladocsPageUrl
 @import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("TimesOnInt") {

--- a/app/views/userGuide/Tolerance.scala.html
+++ b/app/views/userGuide/Tolerance.scala.html
@@ -15,7 +15,7 @@
 *@
 
 @import controllers.Application.milestoneScaladoc
-@import controllers.Application.latestScaladoc
+@import controllers.Application.scalatestScaladocsPageUrl
 @import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Tolerance") {

--- a/app/views/userGuide/Tolerance.scala.html
+++ b/app/views/userGuide/Tolerance.scala.html
@@ -16,7 +16,7 @@
 
 @import controllers.Application.milestoneScaladoc
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Tolerance") {
 <div style="text-align: left">
@@ -24,7 +24,7 @@
 <h1>Tolerance</h1>
 
 <p>
-The <a href="@{latestScalacticScaladoc}/#org.scalactic.Tolerance"><code>Tolerance</code></a> trait contains an implicit conversion that adds
+The <a href='@scaladocsPageUrl("org.scalactic.Tolerance")'><code>Tolerance</code></a> trait contains an implicit conversion that adds
 a <code>+-</code> method to <code>Numeric</code> types, which, combined with one of the <code>TripleEquals</code> traits,  enables
 you to determine whether the numeric value is with a tolerance.
 </p>

--- a/app/views/userGuide/constrainedEquality.scala.html
+++ b/app/views/userGuide/constrainedEquality.scala.html
@@ -14,7 +14,7 @@
 * limitations under the License.
 *@
 
-@import controllers.Application.latestScaladoc
+@import controllers.Application.scalatestScaladocsPageUrl
 @import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Constrained Equality") {

--- a/app/views/userGuide/constrainedEquality.scala.html
+++ b/app/views/userGuide/constrainedEquality.scala.html
@@ -15,7 +15,7 @@
 *@
 
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Constrained Equality") {
 <div style="text-align: left">
@@ -24,7 +24,7 @@
 
 <p>
 Scalactic provides a way to get a compile-time type error if two types being compared with <code>===</code> violate a tunable type
-<a href="@{latestScalacticScaladoc}/#org.scalactic.Constraint"><code>Constraint</code></a>. The basic <a href="@{latestScalacticScaladoc}/#org.scalactic.TripleEquals"><code>TripleEquals</code></a> trait allows you to compare any
+<a href='@scaladocsPageUrl("org.scalactic.Constraint")'><code>Constraint</code></a>. The basic <a href='@scaladocsPageUrl("org.scalactic.TripleEquals")'><code>TripleEquals</code></a> trait allows you to compare any
 type for equality with any other type:
 </p>
 
@@ -43,7 +43,7 @@ res1: Boolean = true
 </pre>
 
 <p>
-<a href="@{latestScalacticScaladoc}/#org.scalactic.TypeCheckedTripleEquals"><code>TypeCheckedTripleEquals</code></a> will compile only if the left and right sides are in a subtype/supertype relationship (including
+<a href='@scaladocsPageUrl("org.scalactic.TypeCheckedTripleEquals")'><code>TypeCheckedTripleEquals</code></a> will compile only if the left and right sides are in a subtype/supertype relationship (including
 when the left and right sides are exactly the same type):
 </p>
 
@@ -85,7 +85,7 @@ Since every type is a subtype of <code>Any</code>, you can always solve an over-
 </p>
 <p>
 Another way to address this type error, since an implicit conversion exists between the two types, is to use
-<a href="@{latestScalacticScaladoc}/#org.scalactic.ConversionCheckedTripleEquals"><code>ConversionCheckedTripleEquals</code></a>.
+<a href='@scaladocsPageUrl("org.scalactic.ConversionCheckedTripleEquals")'><code>ConversionCheckedTripleEquals</code></a>.
 <code>ConversionCheckedTripleEquals</code> will compile if the left and right sides are
 in a subtype/supertype relationship <em>or</em> an implicit conversion exists between the left and right sides:
 </p>

--- a/app/views/userGuide/customEquality.scala.html
+++ b/app/views/userGuide/customEquality.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.Application.latestScaladoc
+@import controllers.Application.scalatestScaladocsPageUrl
 @import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Custom equality") {
@@ -25,7 +25,7 @@
 <p>
 Scalactic's <a href='@scaladocsPageUrl("org.scalactic.Equality")'><code>Equality</code></a> typeclass enables you to define
 alternate notions of equality for specified types that can be used with
-Scalactic's <code>===</code> and <code>!==</code> syntax (and <a href="@{latestScaladoc}/#org.scalatest.Matchers">ScalaTest's matcher</a>) syntax.
+Scalactic's <code>===</code> and <code>!==</code> syntax (and <a href='@scalatestScaladocsPageUrl("org.scalatest.Matchers")'>ScalaTest's matcher</a>) syntax.
 </p>
 
 <p>

--- a/app/views/userGuide/customEquality.scala.html
+++ b/app/views/userGuide/customEquality.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Custom equality") {
 <div style="text-align: left">
@@ -23,7 +23,7 @@
 <h1>Custom equality</h1>
 
 <p>
-Scalactic's <a href="@{latestScalacticScaladoc}/#org.scalactic.Equality"><code>Equality</code></a> typeclass enables you to define
+Scalactic's <a href='@scaladocsPageUrl("org.scalactic.Equality")'><code>Equality</code></a> typeclass enables you to define
 alternate notions of equality for specified types that can be used with
 Scalactic's <code>===</code> and <code>!==</code> syntax (and <a href="@{latestScaladoc}/#org.scalatest.Matchers">ScalaTest's matcher</a>) syntax.
 </p>
@@ -55,7 +55,7 @@ res0: Boolean = false
 </pre>
 
 <p>
-Scalactic's <a href="@{latestScalacticScaladoc}/#org.scalactic.TripleEquals"><code>===</code> operator</a> looks for an implicit <code>Equality[L]</code>, where <code>L</code> is the left-hand type: in this
+Scalactic's <a href='@scaladocsPageUrl("org.scalactic.TripleEquals")'><code>===</code> operator</a> looks for an implicit <code>Equality[L]</code>, where <code>L</code> is the left-hand type: in this
 case, <code>Person</code>. Because you didn't specifically provide an implicit <code>Equality[Person]</code>, <code>===</code> will fall back on
 <a href="DefaultEquality"><em>default equality</em></a>, which will call <code>Person</code>'s <code>equals</code> method. That <code>equals</code> method, provided by the Scala compiler
 because <code>Person</code> is a case class, will declare these two objects unequal because 29.001 does not exactly equal 29.0.

--- a/app/views/userGuide/defaultEquality.scala.html
+++ b/app/views/userGuide/defaultEquality.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.Application.latestScaladoc
+@import controllers.Application.scalatestScaladocsPageUrl
 @import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Default equality") {
@@ -108,14 +108,14 @@ Here's the <code>areEqual</code> method implementation from the earlier <code>Eq
 </pre>
 
 <p>
-<code>Equality</code> is used by <a href="@{latestScaladoc}/#org.scalactic.TripleEquals" target="_blank"><code>TripleEquals</code></a>,
+<code>Equality</code> is used by <a href='@scalatestScaladocsPageUrl("org.scalactic.TripleEquals")' target="_blank")'><code>TripleEquals</code></a>,
 which enforces no type constraint between the left and right values, and the <code>equal</code>, <code>be</code>, and <code>contain</code> syntax of ScalaTest Matchers.
 </p>
 
 <p>
-By contrast, <a href="@{latestScaladoc}/#org.scalactic.TypeCheckedTripleEquals" target="_blank"><code>TypeCheckedTripleEquals</code></a>
-and <a href="@{latestScaladoc}/#org.scalactic.ConversionCheckedTripleEquals" target="_blank"><code>ConversionCheckedTripleEquals</code></a>
-use an <a href="@{latestScaladoc}/#org.scalactic.Equivalence" target="_blank"><code>Equivalence</code></a>.
+By contrast, <a href='@scalatestScaladocsPageUrl("org.scalactic.TypeCheckedTripleEquals")' target="_blank")'><code>TypeCheckedTripleEquals</code></a>
+and <a href='@scalatestScaladocsPageUrl("org.scalactic.ConversionCheckedTripleEquals")' target="_blank")'><code>ConversionCheckedTripleEquals</code></a>
+use an <a href='@scalatestScaladocsPageUrl("org.scalactic.Equivalence")' target="_blank")'><code>Equivalence</code></a>.
 <code>Equivalence</code> differs from <code>Equality</code> in that both the left and right values are of the same type. <code>Equivalence</code> works for
 <code>TypeCheckedTripleEquals</code> because the type constraint enforces that the left type is a subtype or supertype of (or the same type as) the right
 type, and it <em>widens</em> the subtype to the supertype. So ultimately, both left and right sides are of the supertype type. Similarly, <code>Equivalence</code>
@@ -135,7 +135,7 @@ method might look:
 <p>
 Scalactic provides both <code>Equality</code> and <code>Equivalence</code> because the <code>Any</code> in
 <code>Equality</code> can sometimes make things painful. For example, in trait
-<a href="@{latestScaladoc}/#org.scalactic.TolerantNumerics" target="_blank"><code>TolerantNumerics</code></a>,
+<a href='@scalatestScaladocsPageUrl("org.scalactic.TolerantNumerics")' target="_blank")'><code>TolerantNumerics</code></a>,
 a single generic factory method can produce <code>Equivalence</code>s for any <code>Numeric</code> type,
 but because of the <code>Any</code>, a separate factory method must be defined to produce an <code>Equality</code>
 for each <code>Numeric</code> type.

--- a/app/views/userGuide/defaultEquality.scala.html
+++ b/app/views/userGuide/defaultEquality.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import controllers.Application.latestScaladoc
-@import controllers.Application.latestScalacticScaladoc
+@import controllers.Application.scaladocsPageUrl
 
 @userGuidePage("Default equality") {
 <div style="text-align: left">
@@ -61,9 +61,9 @@ res5: Boolean = true
 </pre>
 
 <p>
-You can obtain a default equality via the <code>default</code> method of the <a href="@{latestScalacticScaladoc}/#org.scalactic.Equality$">
+You can obtain a default equality via the <code>default</code> method of the <a href='@scaladocsPageUrl("org.scalactic.Equality$")'>
 Equality companion object</a>, or from the <code>defaultEquality</code> method defined in
-<a href="@{latestScalacticScaladoc}/#org.scalactic.TripleEqualsSupport"><code>TripleEqualsSupport</code></a>.
+<a href='@scaladocsPageUrl("org.scalactic.TripleEqualsSupport")'><code>TripleEqualsSupport</code></a>.
 </p>
 
 <!--

--- a/app/views/userGuide/userGuideIndex.scala.html
+++ b/app/views/userGuide/userGuideIndex.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.Application.latestScaladoc
+@import controllers.Application.scalatestScaladocsPageUrl
 
 @userGuidePage("User Guide") {
 


### PR DESCRIPTION
Replaced latestScaladoc with scalatestScaladocsPageUrl and latestScalacticScaladoc with scaladocsPageUrl.