### PR TITLE
SuperSafe Note for Scala 3 in Install Page

### DIFF
--- a/app/views/install.scala.html
+++ b/app/views/install.scala.html
@@ -56,8 +56,8 @@ libraryDependencies += <span class="stQuotedString">"org.scalactic"</span> %% <s
 </pre>
 
 <p>
-2. We also recommend you also include the <a href="/supersafe">SuperSafe Community Edition</a> Scala compiler plugin, which will flag errors in your 
-Scalactic code at compile time, by first adding this line to <code>~/.sbt/0.13/global.sbt</code>:
+2. We also recommend you also include the <a href="/supersafe">SuperSafe Community Edition</a> Scala compiler plugin for Scala 2.x (not supported for Scala 3.x), which will flag errors in your
+Scalactic code at compile time, by first adding this line to <code>~/.sbt/1.0/global.sbt</code>:
 </p>
 
 <pre class="stHighlighted">
@@ -95,7 +95,7 @@ You are off and running! As a next step, visit the <a href="/user_guide">Getting
 </pre>
 
 <p>
-2. We also recommend you also include the <a href="/supersafe">SuperSafe Community Edition</a> Scala compiler plugin, which will flag errors in your
+2. We also recommend you also include the <a href="/supersafe">SuperSafe Community Edition</a> Scala compiler plugin for Scala 2.x (not supported for Scala 3.x), which will flag errors in your
 Scalactic code at compile time, by adding the following lines to your <code>pom.xml</code>:
 </p>
 


### PR DESCRIPTION
Added a note about SuperSafe not being supported in Scala 3 in the install page.