### PR TITLE
Fix Scaladoc for Old Versions

### DIFF
--- a/app/views/scaladoc.scala.html
+++ b/app/views/scaladoc.scala.html
@@ -63,12 +63,11 @@ this page prior to version 3.0.0 link to the Scalactic portion of ScalaTest's Sc
 <li><a href="@routes.Assets.at("/public/scaladoc", "3.0.2/index.html#org.scalactic.Or")">Scaladoc for Scalactic 3.0.2</a> (for Scala 2.11.0+, 2.10.0+, and 2.12.0+, both on the JVM and on Scala.js 0.6.13)</li>
 <li><a href="@routes.Assets.at("/public/scaladoc", "3.0.1/index.html#org.scalactic.Or")">Scaladoc for Scalactic 3.0.1</a> (for Scala 2.11.0+, 2.10.0+, and 2.12.0+, both on the JVM and on Scala.js 0.6.13)</li>
 <li><a href="@routes.Assets.at("/public/scaladoc", "3.0.0/index.html#org.scalactic.Or")">Scaladoc for Scalactic 3.0.0</a> (for Scala 2.11.0+, 2.10.0+, and 2.12.0+, both on the JVM and on Scala.js 0.6.11)</li>
-<li><a href="http://doc.scalatest.org/2.2.6/index.html#org.scalactic.Or">Scaladoc for Scalactic 2.2.6</a> (for Scala 2.11.0+ and 2.10.0+)</li>
-<li><a href="http://doc.scalatest.org/2.2.6/index.html#org.scalactic.Or">Scaladoc for Scalactic 2.2.6</a> (for Scala 2.11.0+ and 2.10.0+)</li>
-<li><a href="http://doc.scalatest.org/2.2.4/index.html#org.scalactic.package">Scaladoc for Scalactic 2.2.4</a> (for Scala 2.11.0+ and 2.10.0+)</li>
-<li><a href="http://doc.scalatest.org/2.2.2/index.html#org.scalactic.package">Scaladoc for Scalactic 2.2.2</a> (for Scala 2.11.0+ and 2.10.0+)</li>
-<li><a href="http://doc.scalatest.org/2.2.1/index.html#org.scalactic.package">Scaladoc for Scalactic 2.2.1</a> (for Scala 2.11.0+ and 2.10.0+)</li>
-<li><a href="http://doc.scalatest.org/2.2.0/index.html#org.scalactic.package">Scaladoc for Scalactic 2.2.0</a> (for Scala 2.11.0+ and 2.10.0+)</li>
+<li><a href="https://www.scalatest.org/scaladoc/2.2.6/index.html#org.scalactic.Or">Scaladoc for Scalactic 2.2.6</a> (for Scala 2.11.0+ and 2.10.0+)</li>
+<li><a href="https://www.scalatest.org/scaladoc/2.2.4/index.html#org.scalactic.package">Scaladoc for Scalactic 2.2.4</a> (for Scala 2.11.0+ and 2.10.0+)</li>
+<li><a href="https://www.scalatest.org/scaladoc/2.2.2/index.html#org.scalactic.package">Scaladoc for Scalactic 2.2.2</a> (for Scala 2.11.0+ and 2.10.0+)</li>
+<li><a href="https://www.scalatest.org/scaladoc/2.2.1/index.html#org.scalactic.package">Scaladoc for Scalactic 2.2.1</a> (for Scala 2.11.0+ and 2.10.0+)</li>
+<li><a href="https://www.scalatest.org/scaladoc/2.2.0/index.html#org.scalactic.package">Scaladoc for Scalactic 2.2.0</a> (for Scala 2.11.0+ and 2.10.0+)</li>
 </ul>
 
 </div>


### PR DESCRIPTION
Point scaladocs of Scalactic 2.x version to scaladocs hosted on scalatest.org, instead of docs.scalatest.org.