### PR TITLE
Base Scala Version 2.13.14

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -68,7 +68,7 @@ object Application {
   val milestoneScaladoc = "http://www.artima.com/docs-scalatest-3.1.0-RC3"
   val scaladocsLocation = "http://doc.scalatest.org"
   val releasesLocation = "http://www.artima.com/downloadScalaTest"
-  val baseScalaVersion = "2.13.12"
+  val baseScalaVersion = "2.13.14"
   val majorMinorScalaVersion = "2.13"
 
   def scaladocsPageUrl(file: String, version: String = latestVersion): String = {

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -62,14 +62,15 @@ object Application {
 
   val latestVersion = "3.2.18"
   val latestSuperSafeVersion = "1.1.12"
+  val supersafeScalaVersion = "2.13.14"
   val milestoneVersion = "3.1.0-RC3"
   val milestoneJar = "https://oss.sonatype.org/content/groups/public/org/scalactic/scalactic_2.13/3.1.0-RC3/scalactic_2.10-3.1.0-RC3.jar"
   val latestJar = s"https://oss.sonatype.org/content/groups/public/org/scalactic/scalactic_2.13/$latestVersion/scalactic_2.13-$latestVersion.jar"
   val milestoneScaladoc = "http://www.artima.com/docs-scalatest-3.1.0-RC3"
   val scaladocsLocation = "http://doc.scalatest.org"
   val releasesLocation = "http://www.artima.com/downloadScalaTest"
-  val baseScalaVersion = "2.13.14"
-  val majorMinorScalaVersion = "2.13"
+  val baseScalaVersion = "3.3.3"
+  val majorMinorScalaVersion = "3"
 
   def scaladocsPageUrl(file: String, version: String = latestVersion): String = {
     val oldScaladocStyle30Releases = List("3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.0.4")

--- a/app/views/install.scala.html
+++ b/app/views/install.scala.html
@@ -19,7 +19,7 @@
 @import controllers.Application.latestVersion
 @import controllers.Application.majorMinorScalaVersion
 @import controllers.Application.latestSuperSafeVersion
-@import controllers.Application.baseScalaVersion
+@import controllers.Application.supersafeScalaVersion
 @import controllers.Application.scaladocsPageUrl
 
 @nonHomePage("Install") {
@@ -120,7 +120,7 @@ Scalactic code at compile time, by adding the following lines to your <code>pom.
         &lt;compilerPlugins&gt;
             &lt;compilerPlugin&gt;
                 &lt;groupId&gt;com.artima.supersafe&lt;/groupId&gt;
-                &lt;artifactId&gt;supersafe_@{baseScalaVersion}&lt;/artifactId&gt;
+                &lt;artifactId&gt;supersafe_@{supersafeScalaVersion}&lt;/artifactId&gt;
                 &lt;version&gt;@{latestSuperSafeVersion}&lt;/version&gt;
             &lt;/compilerPlugin&gt;
         &lt;/compilerPlugins&gt;

--- a/app/views/supersafe.scala.html
+++ b/app/views/supersafe.scala.html
@@ -16,7 +16,7 @@
 
 @import controllers.Application.latestSuperSafeVersion
 @import controllers.Application.scaladocsPageUrl
-@import controllers.Application.baseScalaVersion
+@import controllers.Application.supersafeScalaVersion
 
 @nonHomePage("SuperSafe") {
 <div style="text-align: left">
@@ -105,7 +105,7 @@ If you are using Maven as your build tool, you can install the community edition
         &lt;compilerPlugins&gt;
             <b>&lt;compilerPlugin&gt;
                 &lt;groupId&gt;com.artima.supersafe&lt;/groupId&gt;
-                &lt;artifactId&gt;supersafe_@{baseScalaVersion}&lt;/artifactId&gt;
+                &lt;artifactId&gt;supersafe_@{supersafeScalaVersion}&lt;/artifactId&gt;
                 &lt;version&gt;@{latestSuperSafeVersion}&lt;/version&gt;
             &lt;/compilerPlugin&gt;</b>
         &lt;/compilerPlugins&gt;

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file(".")).settings(
   name := "scalactic",
-  version := "240508",
+  version := "240508b",
   scalaVersion := "3.3.1",
   libraryDependencies ++= Seq(
     guice,

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file(".")).settings(
   name := "scalactic",
-  version := "240229",
+  version := "240508",
   scalaVersion := "3.3.1",
   libraryDependencies ++= Seq(
     guice,


### PR DESCRIPTION
Updated base scala version from 2.13.12 to 2.13.14, one place it will be shown is in SuperSafe installation guide for maven.